### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/msn-kit/Cargo.toml
+++ b/msn-kit/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.2.5"
 edition = "2021"
 license = "MIT"
 description = "Library and CLI for working with Mass Spec data."
-homepage = "http://www.github.com/tshauck/msn-kit"
+homepage = "https://www.github.com/tshauck/msn-kit"
 documentation = "https://docs.rs/msn-kit/0.1.0/msn_kit/"
-repository = "http://www.github.com/tshauck/msn-kit"
+repository = "https://www.github.com/tshauck/msn-kit"
 readme = "../README.md"
 
 [lib]


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97